### PR TITLE
Use options.modifier for output only #4

### DIFF
--- a/lib/addons/bem.js
+++ b/lib/addons/bem.js
@@ -37,10 +37,12 @@ export default function(tree, options) {
  */
 function expandClassNames(node, options) {
 	const classNames = node.classList.reduce((out, cl) => {
-		// remove all modifiers from class name to get a base element name
-		const ix = cl.indexOf(options.modifier);
-		if (ix !== -1) {
+		// remove all modifiers and element prefixes from class name to get a base element name
+		const ix = cl.indexOf('_');
+		if (ix > 0 && !cl.startsWith('-')) {
 			out.add(cl.slice(0, ix));
+		    out.add(cl.slice(ix));
+			return out;
 		}
 
 		return out.add(cl);

--- a/test/bem.js
+++ b/test/bem.js
@@ -26,4 +26,10 @@ describe('BEM transform', () => {
 		// get block name from proper ancestor
 		assert.equal(expand('div.b1>div.b2_m1>div.-e1+div.--e2_m2'), '<div class="b1"><div class="b2 b2_m1"><div class="b2__e1"></div><div class="b1__e2 b1__e2_m2"></div></div></div>');
 	});
+
+	it('customize modifier', () => {
+		const expandWithOptions = (abbr, options) => stringify( bem( parse(abbr), options ) );
+		assert.equal(expandWithOptions('div.b_m', {element: '-', modifier: '__'}), '<div class="b b__m"></div>');
+		assert.equal(expandWithOptions('div.b._m', {element: '-', modifier: '__'}), '<div class="b b__m"></div>');
+	});
 });


### PR DESCRIPTION
`options.modifier` is meant to be used only for the output of the bem transformation
Since it was also used to find the base element name, customizing the modifier via options was not working as expected.

The change done in this PR is to decipher base element name only if the className doesnt start with either `-` or `_`

This fixes #4

cc @sergeche
