### PR TITLE
Adding the ability to number in descending order.

### DIFF
--- a/lib/numbering.js
+++ b/lib/numbering.js
@@ -104,7 +104,7 @@ function getNumberingRanges(str) {
  * @return {String}
  */
 function replaceNumberingRanges(str, ranges, value, count) {
-    const replaced = replaceRanges(str, ranges, (token, offset, descendingOrder=false) => {
+    const replaced = replaceRanges(str, ranges, (token, offset, descendingOrder) => {
     let _value = descendingOrder ? String(offset + count - value + 1) : String(value + offset);
         // pad values for multiple numbering tokens, e.g. 3 for $$$ becomes 003
         while (_value.length < token.length) {

--- a/lib/numbering.js
+++ b/lib/numbering.js
@@ -27,13 +27,14 @@ function applyNumbering(node) {
         // it solves issues with abbreviations like `xsl:if[test=$foo]` where
         // `$foo` is preferred output
         const value = repeater.value;
+        const count = repeater.count;
 
-        node.name = replaceNumbering(node.name, value);
-        node.value = replaceNumbering(node.value, value);
+        node.name = replaceNumbering(node.name, value, count);
+        node.value = replaceNumbering(node.value, value, count);
         node.attributes.forEach(attr => {
             const copy = node.getAttribute(attr.name).clone();
-            copy.name = replaceNumbering(attr.name, value);
-            copy.value = replaceNumbering(attr.value, value);
+            copy.name = replaceNumbering(attr.name, value, count);
+            copy.value = replaceNumbering(attr.value, value, count);
             node.replaceAttribute(attr.name, copy);
         });
     }
@@ -62,12 +63,12 @@ function findRepeater(node) {
  * @param  {Number} value
  * @return {String}
  */
-function replaceNumbering(str, value) {
+function replaceNumbering(str, value, count) {
     // replace numbering in strings only: skip explicit wrappers that could
     // contain unescaped numbering tokens
     if (typeof str === 'string') {
         const ranges = getNumberingRanges(str);
-        return replaceNumberingRanges(str, ranges, value);
+        return replaceNumberingRanges(str, ranges, value, count);
     }
 
     return str;
@@ -102,9 +103,9 @@ function getNumberingRanges(str) {
  * @param  {Number} value
  * @return {String}
  */
-function replaceNumberingRanges(str, ranges, value) {
-    const replaced = replaceRanges(str, ranges, (token, offset) => {
-        let _value = String(value + offset);
+function replaceNumberingRanges(str, ranges, value, count) {
+    const replaced = replaceRanges(str, ranges, (token, offset, descendingOrder=false) => {
+    let _value = descendingOrder ? String(offset + count - value + 1) : String(value + offset);
         // pad values for multiple numbering tokens, e.g. 3 for $$$ becomes 003
         while (_value.length < token.length) {
             _value = '0' + _value;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -47,16 +47,23 @@ export function replaceRanges(str, ranges, value) {
 
         let offset = 0;
         let offsetLength = 0;
+        let descendingOrder = false;
+
         if (str.substr(r[0] + r[1], 1) === '@'){
-            const matches = str.substr(r[0] + r[1] + 1).match(/^(\d+)/);
+            if (str.substr(r[0] + r[1] + 1, 1) === '-') {
+                descendingOrder = true;
+            } 
+            const matches = str.substr(r[0] + r[1] + 1 + Number(descendingOrder)).match(/^(\d+)/);
             if (matches) {
-                offsetLength = matches[1].length + 1;
+                offsetLength = matches[1].length + 1 + Number(descendingOrder);
                 offset = parseInt(matches[1]) - 1;
+            } else {
+                offsetLength = 2;
             }
         }
 
 		str = str.substring(0, r[0])
-			+ (typeof value === 'function' ? value(str.substr(r[0], r[1]), offset) : value)
+			+ (typeof value === 'function' ? value(str.substr(r[0], r[1]), offset, descendingOrder) : value)
 			+ str.substring(r[0] + r[1] + offsetLength);
 	}
 

--- a/test/numbering.js
+++ b/test/numbering.js
@@ -45,5 +45,13 @@ describe('Item numbering', () => {
 	it('add offset to numbering', () => {
 		assert.equal(expand('span.item$@3*2'), '<span class="item3"></span><span class="item4"></span>');
 		assert.equal(expand('span.item$$@3*2'), '<span class="item03"></span><span class="item04"></span>');
+		assert.equal(expand('span.item$@*2'), '<span class="item1"></span><span class="item2"></span>');
 	});
+	it('numbering in descending order', () => {
+		assert.equal(expand('span.item$@-*2'), '<span class="item2"></span><span class="item1"></span>');
+		assert.equal(expand('span.item$@-3*2'), '<span class="item4"></span><span class="item3"></span>');
+		assert.equal(expand('span.item$@-9*2'), '<span class="item10"></span><span class="item9"></span>');		
+		assert.equal(expand('span.item$$@-9*2'), '<span class="item10"></span><span class="item09"></span>');		
+		assert.equal(expand('span$.item$@-*2'), '<span1 class="item2"></span1><span2 class="item1"></span2>');
+	})
 });


### PR DESCRIPTION
#### Making a few changes that allow emmet to do numbering in descending order.

Example input: `span$.item$@-*2`
Current output:
```
<span1 class="item1@-"></span1>
<span2 class="item2@-"></span2>
```
Fixed output:
```
<span1 class="item2"></span1>
<span2 class="item1"></span2>
```

#### Also fixed a minor issue, where `@` modifier without a base or direction was parsed as a character.
Example input: `div$@*2`
Current output:
```
<div1@></div1@>
<div2@></div2@>
```
