### PR TITLE
Support multiple classes after modifier/element

### DIFF
--- a/lib/addons/bem.js
+++ b/lib/addons/bem.js
@@ -142,5 +142,12 @@ function getBlockName(node, lookup, prefix) {
 }
 
 function find(arr, filter) {
-	return arr.filter(filter)[0];
+	for(let i = 0; i < arr.length; i++){
+		if (reElement.test(arr[i]) || reModifier.test(arr[i])) {
+			break;
+		}
+		if (filter(arr[i])) {
+			return arr[i];
+		}
+	}
 }

--- a/test/bem.js
+++ b/test/bem.js
@@ -38,4 +38,10 @@ describe('BEM transform', () => {
 		assert.equal(expandWithOptions('div.b_m', {element: '-', modifier: '__'}), '<div class="b b__m"></div>');
 		assert.equal(expandWithOptions('div.b._m', {element: '-', modifier: '__'}), '<div class="b b__m"></div>');
 	});
+
+	it('multiple classes after modifier/element', () => {
+		assert.equal(expand('div.b_m.c'), '<div class="b b_m c"></div>');
+		assert.equal(expand('div.b>div._m.c'), '<div class="b"><div class="b b_m c"></div></div>');
+		assert.equal(expand('div.b>div.-m.c'), '<div class="b"><div class="b__m c"></div></div>');
+	})
 });


### PR DESCRIPTION
Fixes #12

The lookup table for block names goes through all the classes of the child element. If none found, then it looks at the parent.

But it should stop searching the minute one of the classes is a modifier or element

cc @sergeche 