### PR TITLE
Allow underscore in class names

### DIFF
--- a/lib/addons/bem.js
+++ b/lib/addons/bem.js
@@ -6,7 +6,7 @@ const defaultOptions = {
 };
 
 const reElement  = /^(-+)([a-z0-9]+[a-z0-9-]*)/i;
-const reModifier = /^(_+)([a-z0-9]+[a-z0-9-]*)/i;
+const reModifier = /^(_+)([a-z0-9]+[a-z0-9-_]*)/i;
 const blockCandidates1 = className => /^[a-z]\-/i.test(className);
 const blockCandidates2 = className => /^[a-z]/i.test(className);
 
@@ -71,8 +71,8 @@ function expandShortNotation(node, lookup, options) {
 			cl = cl.slice(m[0].length);
 		}
 
-		// parse modifiers definitions (may contain multiple)
-		while (m = cl.match(reModifier)) {
+		// parse modifiers definitions 
+		if (m = cl.match(reModifier)) {
 			if (!prefix) {
 				prefix = getBlockName(node, lookup, m[1]);
 				out.add(prefix);

--- a/test/bem.js
+++ b/test/bem.js
@@ -31,6 +31,9 @@ describe('BEM transform', () => {
 	
 		// classnames with -
 		assert.equal(expand('div.b>div.-m1-m2'), '<div class="b"><div class="b__m1-m2"></div></div>');
+
+		// classnames with _
+		assert.equal(expand('div.b_m_o'), '<div class="b b_m_o"></div>');
 	});
 
 	it('customize modifier', () => {


### PR DESCRIPTION
Fixes #14

In a single class name there can be only 1 modifier

`.a_b_c` should expand to `<div class="a a_b_c"></div>`
`.a_b._c` should expand to `<div class="a a_b a_c"></div>`

cc @sergeche 