### PR TITLE
Dont fail when node has no name

### DIFF
--- a/lib/repeater-content.js
+++ b/lib/repeater-content.js
@@ -179,7 +179,7 @@ function setNodeContent(node, content) {
 		}
 	}
 
-	if (node.name.toLowerCase() === 'a' || node.hasAttribute('href')) {
+	if ((node.name && node.name.toLowerCase() === 'a') || node.hasAttribute('href')) {
 		// special case: inserting content into `<a>` tag
 		if (reUrl.test(content)) {
 			node.setAttribute('href', (reProto.test(content) ? '' : 'http://') + content);


### PR DESCRIPTION
Abbreviations like `c` get resolved to node with no name which will result in errors when lower casing the node name

cc @sergeche 
